### PR TITLE
Defer format! when using .context

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -191,7 +191,7 @@ impl Config {
   pub fn from_path(path: &Path) -> Result<Config, Error> {
     let mut file = String::new();
     File::open(path)?.read_to_string(&mut file)?;
-    let config = toml::from_str(&file).context(format!("failed to parse config file {:?}", path))?;
+    let config = toml::from_str(&file).with_context(|| format!("failed to parse config file {:?}", path))?;
     Ok(config)
   }
 
@@ -205,7 +205,8 @@ impl Config {
       .depots
       .get(depot)
       .ok_or_else(|| format_err!("unknown depot {}", depot))?;
-    let path = Config::expand_path(&depot_config.path).context(format!("failed to expand path for depot {}", depot))?;
+    let path =
+      Config::expand_path(&depot_config.path).with_context(|| format!("failed to expand path for depot {}", depot))?;
 
     Depot::new(depot.to_string(), path)
   }

--- a/src/depot.rs
+++ b/src/depot.rs
@@ -58,7 +58,7 @@ impl Depot {
     } else {
       git2::Repository::init(dst)
     };
-    let repo = repo.context(format!("failed to create repository at {:?}", dst))?;
+    let repo = repo.with_context(|| format!("failed to create repository at {:?}", dst))?;
 
     let git_path = if bare { dst.to_path_buf() } else { dst.join(".git") };
 
@@ -67,7 +67,7 @@ impl Depot {
     let source_path = src.join("objects");
     let alternates_contents = format!("{}\n", source_path.to_str().unwrap());
     std::fs::write(&alternates_path, &alternates_contents)
-      .context(format!("failed to set alternates for new repository {:?}", dst))?;
+      .with_context(|| format!("failed to set alternates for new repository {:?}", dst))?;
 
     Ok(repo)
   }
@@ -96,7 +96,7 @@ impl Depot {
       return Ok(());
     }
 
-    std::fs::create_dir_all(dst).context(format!("failed to create directory {:?}", dst))?;
+    std::fs::create_dir_all(dst).with_context(|| format!("failed to create directory {:?}", dst))?;
 
     let mut src_mtimes = HashMap::new();
     let mut src_directories = HashSet::new();
@@ -209,7 +209,7 @@ impl Depot {
     // Disable automatic `git gc`.
     let mut config = objects_repo
       .config()
-      .context(format!("failed to get config for repo at {:?}", objects_path))?;
+      .with_context(|| format!("failed to get config for repo at {:?}", objects_path))?;
     config.set_i32("gc.auto", 0).context("failed to set gc.auto")?;
 
     // Always use git directly.
@@ -306,10 +306,10 @@ impl Depot {
     let head = util::parse_revision(&repo, &remote_config.name, branch)?;
     repo
       .checkout_tree(&head, None)
-      .context(format!("failed to checkout HEAD at {:?}", repo.path()))?;
+      .with_context(|| format!("failed to checkout HEAD at {:?}", repo.path()))?;
     repo
       .set_head_detached(head.id())
-      .context(format!("failed to set HEAD to {:?}", repo.path()))?;
+      .with_context(|| format!("failed to set HEAD to {:?}", repo.path()))?;
     Ok(())
   }
 

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -137,7 +137,7 @@ impl Project {
       .clone()
       .ok_or(())
       .or_else(|_| self.find_revision(manifest))
-      .context(format!("project {} has no dest_branch or revision", self.name))?;
+      .with_context(|| format!("project {} has no dest_branch or revision", self.name))?;
 
     Ok(dest_branch)
   }

--- a/src/manifest/parser.rs
+++ b/src/manifest/parser.rs
@@ -27,7 +27,7 @@ pub(crate) fn parse(directory: &Path, file: &Path) -> Result<Manifest, Error> {
 }
 
 fn parse_impl(manifest: &mut Manifest, directory: &Path, file: &Path) -> Result<(), Error> {
-  let mut reader = Reader::from_file(file).context(format!("failed to read manifest file {:?}", file))?;
+  let mut reader = Reader::from_file(file).with_context(|| format!("failed to read manifest file {:?}", file))?;
   reader.trim_text(true);
 
   let mut found_manifest = false;
@@ -35,7 +35,7 @@ fn parse_impl(manifest: &mut Manifest, directory: &Path, file: &Path) -> Result<
   loop {
     let event = reader
       .read_event(&mut buf)
-      .context(format!("failed to parse XML at position {}", reader.buffer_position()))?;
+      .with_context(|| format!("failed to parse XML at position {}", reader.buffer_position()))?;
 
     match event {
       Event::Start(e) => {
@@ -91,7 +91,7 @@ fn parse_manifest(
   loop {
     let event = reader
       .read_event(&mut buf)
-      .context(format!("failed to parse XML at position {}", reader.buffer_position()))?;
+      .with_context(|| format!("failed to parse XML at position {}", reader.buffer_position()))?;
 
     match event {
       Event::Start(e) => {
@@ -191,7 +191,7 @@ fn parse_notice(_event: &BytesStart, reader: &mut Reader<impl BufRead>) -> Resul
   loop {
     let event = reader
       .read_event(&mut buf)
-      .context(format!("failed to parse XML at position {}", reader.buffer_position()))?;
+      .with_context(|| format!("failed to parse XML at position {}", reader.buffer_position()))?;
 
     match event {
       Event::Start(e) => bail!(
@@ -419,7 +419,7 @@ fn parse_project(event: &BytesStart, reader: &mut Reader<impl BufRead>, has_chil
     loop {
       let event = reader
         .read_event(&mut buf)
-        .context(format!("failed to parse XML at position {}", reader.buffer_position()))?;
+        .with_context(|| format!("failed to parse XML at position {}", reader.buffer_position()))?;
 
       match event {
         Event::Start(e) => bail!(

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -345,7 +345,7 @@ impl<'repo> BranchInfo<'repo> {
     let commit = branch
       .get()
       .peel_to_commit()
-      .context(format!("failed to get commit for {}", name))?;
+      .with_context(|| format!("failed to get commit for {}", name))?;
 
     Ok(BranchInfo {
       name: name.to_string(),
@@ -363,14 +363,16 @@ impl<'repo> BranchInfo<'repo> {
     branch_name: &str,
     branch_type: git2::BranchType,
   ) -> Result<BranchInfo<'repo>, Error> {
-    BranchInfo::from_branch(repo.find_branch(branch_name, branch_type).context(format!(
-      "could not find {} branch {}",
-      match branch_type {
-        git2::BranchType::Local => "local",
-        git2::BranchType::Remote => "remote",
-      },
-      branch_name
-    ))?)
+    BranchInfo::from_branch(repo.find_branch(branch_name, branch_type).with_context(|| {
+      format!(
+        "could not find {} branch {}",
+        match branch_type {
+          git2::BranchType::Local => "local",
+          git2::BranchType::Remote => "remote",
+        },
+        branch_name
+      )
+    })?)
   }
 
   fn name_without_remote(&self) -> &str {
@@ -462,7 +464,7 @@ fn summarize_upload(
   for commit_oid in commits {
     let commit = repo
       .find_commit(*commit_oid)
-      .context(format!("could not find commit matching {}", commit_oid))?;
+      .with_context(|| format!("could not find commit matching {}", commit_oid))?;
     commit_summaries.push(CommitSummary {
       id: commit.id(),
       summary: commit
@@ -498,7 +500,7 @@ impl Tree {
     util::assert_empty_directory(&tree_root)?;
     let pore_path = tree_root.join(".pore");
 
-    std::fs::create_dir_all(&pore_path).context(format!("failed to create directory {:?}", pore_path))?;
+    std::fs::create_dir_all(&pore_path).with_context(|| format!("failed to create directory {:?}", pore_path))?;
 
     let manifest_path = pore_path.join("manifest");
     let manifest_file = PathBuf::from("manifest").join(file);
@@ -597,8 +599,8 @@ impl Tree {
     let tree_root = std::fs::canonicalize(&self.path).context("failed to canonicalize tree path")?;
     let mut paths = Vec::new();
     for path in under.unwrap_or_default() {
-      let requested_path =
-        std::fs::canonicalize(&path).context(format!("failed to canonicalize requested path '{}'", path.display()))?;
+      let requested_path = std::fs::canonicalize(&path)
+        .with_context(|| format!("failed to canonicalize requested path '{}'", path.display()))?;
       paths.push(
         pathdiff::diff_paths(&requested_path, &tree_root)
           .ok_or_else(|| format_err!("failed to calculate path diff for {}", path.display()))?,
@@ -707,10 +709,10 @@ impl Tree {
         job.add_task(project_name, move || -> Result<(), Error> {
           let remote = config
             .find_remote(remote_name)
-            .context(format!("failed to find remote {}", remote_name))?;
+            .with_context(|| format!("failed to find remote {}", remote_name))?;
           let depot = config
             .find_depot(&remote.depot)
-            .context(format!("failed to find depot for remote {}", remote_name))?;
+            .with_context(|| format!("failed to find depot for remote {}", remote_name))?;
 
           let target_vec: Option<Vec<String>> = match target {
             FetchTarget::Upstream => panic!("unreified FetchTarget"),
@@ -720,7 +722,7 @@ impl Tree {
           let target = target_vec.as_deref();
           depot
             .fetch_repo(remote, project_name, target, fetch_tags, None)
-            .context(format!("failed to fetch for project {}", project_name,))?;
+            .with_context(|| format!("failed to fetch for project {}", project_name,))?;
           Ok(())
         });
       }
@@ -746,10 +748,10 @@ impl Tree {
         job.add_task(&project.project_path, move || {
           let remote = config
             .find_remote(&project.remote)
-            .context(format!("failed to find remote {}", project.remote))?;
+            .with_context(|| format!("failed to find remote {}", project.remote))?;
           let depot = config
             .find_depot(&remote.depot)
-            .context(format!("failed to find depot for remote {}", project.remote))?;
+            .with_context(|| format!("failed to find depot for remote {}", project.remote))?;
 
           let project_name = &project.project_name;
           let revision = &project.revision;
@@ -780,10 +782,12 @@ impl Tree {
               };
 
               let new_head = util::parse_revision(&repo, &remote.name, revision)
-                .context(format!(
-                  "failed to find revision to sync to (wanted {}/{} in {:?})",
-                  remote.name, revision, project_path
-                ))?
+                .with_context(|| {
+                  format!(
+                    "failed to find revision to sync to (wanted {}/{} in {:?})",
+                    remote.name, revision, project_path
+                  )
+                })?
                 .peel_to_commit()?;
 
               if Some(new_head.id()) == current_head_oid {
@@ -821,14 +825,14 @@ impl Tree {
                     new_head.as_object(),
                     Some(git2::build::CheckoutBuilder::new().dry_run()),
                   )
-                  .context(format!("failed to dry run checkout to {:?}", new_head))?;
+                  .with_context(|| format!("failed to dry run checkout to {:?}", new_head))?;
 
                 repo
                   .checkout_tree(new_head.as_object(), None)
-                  .context(format!("failed to checkout to {:?}", new_head))?;
+                  .with_context(|| format!("failed to checkout to {:?}", new_head))?;
                 repo
                   .reset(new_head.as_object(), git2::ResetType::Soft, None)
-                  .context(format!("failed to move HEAD to {:?}", new_head))?;
+                  .with_context(|| format!("failed to move HEAD to {:?}", new_head))?;
               }
             } else {
               depot.clone_repo(remote, project_name, revision, &project_path)?;
@@ -854,10 +858,12 @@ impl Tree {
               // TODO: repo uses origin as the upstream, regardless of what the remote is called.
               branch
                 .set_upstream(Some(&format!("{}/{}", project.remote, project.revision)))
-                .context(format!(
-                  "failed to set manifest branch upstream to {}/{}",
-                  project.remote, project.revision
-                ))?;
+                .with_context(|| {
+                  format!(
+                    "failed to set manifest branch upstream to {}/{}",
+                    project.remote, project.revision
+                  )
+                })?;
               repo
                 .set_head("refs/heads/default")
                 .context("failed to set manifest HEAD")?;
@@ -874,7 +880,7 @@ impl Tree {
               let symlink_path = hooks_dir.join(filename);
               let _ = std::fs::remove_file(&symlink_path);
               create_symlink(&target, &symlink_path)
-                .context(format!("failed to create symlink at {:?}", &symlink_path))?;
+                .with_context(|| format!("failed to create symlink at {:?}", &symlink_path))?;
             }
 
             if !no_lfs && Path::exists(&project_path.join(".lfsconfig")) {
@@ -963,7 +969,7 @@ impl Tree {
             .context("failed to create lost+found directory")
             .and_then(|_| {
               std::fs::rename(&src_path, &dst_path)
-                .context(format!("failed to move project from {:?} to {:?}", src_path, dst_path))
+                .with_context(|| format!("failed to move project from {:?} to {:?}", src_path, dst_path))
             });
 
           if let Err(e) = result {
@@ -1010,12 +1016,13 @@ impl Tree {
 
   fn write_hook(&self, directory: &Path, filename: &str, contents: &str) -> Result<(), Error> {
     let path = self.path.join(directory);
-    std::fs::create_dir_all(&path).context(format!("failed to create directory: {:?}", path))?;
+    std::fs::create_dir_all(&path).with_context(|| format!("failed to create directory: {:?}", path))?;
     let file_path = path.join(filename);
-    let mut file = std::fs::File::create(&file_path).context(format!("failed to open file at {:?}", file_path))?;
+    let mut file =
+      std::fs::File::create(&file_path).with_context(|| format!("failed to open file at {:?}", file_path))?;
     file
       .write_all(contents.as_bytes())
-      .context(format!("failed to write hook at {:?}", file_path))?;
+      .with_context(|| format!("failed to write hook at {:?}", file_path))?;
 
     // Currently no std APIs for dealing with file permissions on Windows.
     // Not running this on Windows probably isn't an issue since everything
@@ -1284,12 +1291,12 @@ impl Tree {
     for project in projects {
       job.add_task(project.project_path.clone(), move || -> Result<ProjectStatus, Error> {
         let path = self.path.join(&project.project_path);
-        let repo =
-          git2::Repository::open(&path).context(format!("failed to open repository {}", project.project_path))?;
+        let repo = git2::Repository::open(&path)
+          .with_context(|| format!("failed to open repository {}", project.project_path))?;
 
         let head = repo
           .head()
-          .context(format!("failed to get HEAD for repository {}", project.project_path))?;
+          .with_context(|| format!("failed to get HEAD for repository {}", project.project_path))?;
         let commit = head.peel_to_commit().context("failed to peel HEAD to commit")?;
         let branch = if head.is_branch() {
           Some(head.shorthand().unwrap().to_string())
@@ -1299,7 +1306,7 @@ impl Tree {
 
         let statuses = repo
           .statuses(Some(git2::StatusOptions::new().include_untracked(true)))
-          .context(format!("failed to get status of repository {}", project.project_path))?;
+          .with_context(|| format!("failed to get status of repository {}", project.project_path))?;
 
         let files: Vec<FileStatus> = statuses
           .iter()
@@ -1404,7 +1411,7 @@ impl Tree {
 
     let mut branch = repo
       .branch(&branch_name, &commit, false)
-      .context(format!("failed to create branch {}", branch_name))?;
+      .with_context(|| format!("failed to create branch {}", branch_name))?;
     branch
       .set_upstream(Some(&format!("{}/{}", remote, upstream)))
       .context("failed to set branch upstream")?;
@@ -1412,7 +1419,7 @@ impl Tree {
     repo.checkout_tree(&object, None)?;
     repo
       .set_head(&format!("refs/heads/{}", branch_name))
-      .context(format!("failed to set HEAD to {}", branch_name))?;
+      .with_context(|| format!("failed to set HEAD to {}", branch_name))?;
 
     Ok(0)
   }
@@ -1593,16 +1600,16 @@ impl Tree {
     for project in &projects {
       job.add_task(&project.project_path, move || -> Result<PruneResult, Error> {
         let path = self.path.join(&project.project_path);
-        let tree_repo =
-          git2::Repository::open(&path).context(format!("failed to open repository {:?}", project.project_path))?;
+        let tree_repo = git2::Repository::open(&path)
+          .with_context(|| format!("failed to open repository {:?}", project.project_path))?;
 
         let remote_config = config
           .find_remote(&project.remote)
-          .context(format!("failed to find remote {}", project.remote))?;
+          .with_context(|| format!("failed to find remote {}", project.remote))?;
         let local_project = Depot::apply_project_renames(remote_config, &project.project_name);
         let obj_repo_path = depot.objects_mirror(remote_config, &local_project);
         let obj_repo = git2::Repository::open_bare(&obj_repo_path)
-          .context(format!("failed to open object repository {:?}", obj_repo_path))?;
+          .with_context(|| format!("failed to open object repository {:?}", obj_repo_path))?;
 
         let branches = tree_repo.branches(Some(git2::BranchType::Local))?;
 
@@ -1639,7 +1646,7 @@ impl Tree {
           let mut branch = tree_repo.find_branch(branch_name, git2::BranchType::Local)?;
           branch
             .delete()
-            .context(format!("failed to delete branch {}", branch_name))?;
+            .with_context(|| format!("failed to delete branch {}", branch_name))?;
         }
 
         Ok(PruneResult {
@@ -1734,8 +1741,8 @@ impl Tree {
       let manifest = &manifest;
       job.add_task(&project.project_path, move || -> Result<bool, Error> {
         let path = self.path.join(&project.project_path);
-        let repo =
-          git2::Repository::open(&path).context(format!("failed to open repository {:?}", project.project_path))?;
+        let repo = git2::Repository::open(&path)
+          .with_context(|| format!("failed to open repository {:?}", project.project_path))?;
 
         if repo.head_detached().context("failed to check if HEAD is detached")? {
           // Don't rebase detached HEADs. This behavior matches repo.

--- a/src/util.rs
+++ b/src/util.rs
@@ -98,12 +98,14 @@ pub fn parse_revision<T: AsRef<str>, U: AsRef<str>>(
   // we correctly pick the remote one.
   let object = match repo.revparse_single(&format!("{}/{}", remote, revision)) {
     Ok(obj) => obj,
-    Err(_) => repo.revparse_single(revision).context(format!(
-      "failed to find revision {} from remote {} in {:?}",
-      revision,
-      remote,
-      repo.path()
-    ))?,
+    Err(_) => repo.revparse_single(revision).with_context(|| {
+      format!(
+        "failed to find revision {} from remote {} in {:?}",
+        revision,
+        remote,
+        repo.path()
+      )
+    })?,
   };
 
   Ok(object)


### PR DESCRIPTION
When using context, if formatting a string then use the with_context function that takes a lambda. That way we can defer its execution for when the error variant is returned and displayed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tamird/pore/3)
<!-- Reviewable:end -->
