### PR TITLE
Fix branches subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -464,7 +464,7 @@ fn cmd_branches(config: Config, pool: &mut Pool, tree: &Tree) -> Result<i32, Err
 
   if results.failed.is_empty() {
     let projects_with_topic_branch = results.successful.into_iter().filter_map(|execution_result| {
-      if execution_result.result.branches.is_empty() {
+      if !execution_result.result.branches.is_empty() {
         Some(execution_result.result)
       } else {
         None


### PR DESCRIPTION
We only want to print out the branch if it has a topic branch, not if it does not have any topic branches.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tamird/pore/5)
<!-- Reviewable:end -->
